### PR TITLE
Fix deploy action isn't getting the latest image on remote-end

### DIFF
--- a/.github/workflows/Deployment.yml
+++ b/.github/workflows/Deployment.yml
@@ -82,4 +82,4 @@ jobs:
           before_script: |
             docker compose -f ${{secrets.REMOTE_DIRECTORY}}/compose.yaml pull
           after_script: |
-            docker compose pull docker compose -f ${{secrets.REMOTE_DIRECTORY}}/compose.yaml up -d
+            docker compose -f ${{secrets.REMOTE_DIRECTORY}}/compose.yaml up -d


### PR DESCRIPTION
Refine the deployment workflow by adjusting the script execution order and updating the Docker image tagging strategy.