### PR TITLE
Fix View tables initiation

### DIFF
--- a/src/functions/DB/createDBViews.js
+++ b/src/functions/DB/createDBViews.js
@@ -56,7 +56,7 @@ async function createDataView(year, query_TableName) {
         
         MIN("avg") AS "avg"
       FROM 
-        public."QUERY_${year}_init${process.env.QUERY_POSTFIX}"
+        public."QUERY_${year}_init${process.env.QUERY_POSTFIX || ""}"
     GROUP BY 
       schoolCode,
       schoolName,


### PR DESCRIPTION
Ensure the query uses a default value for the postfix when it is not defined, preventing potential errors during data retrieval.